### PR TITLE
Replace deprecated babel-preset-latest with babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["latest", { "modules": false }],
+    ["env", { "modules": false }],
     "react"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
-    "babel-preset-latest": "^6.22.0",
+    "babel-preset-env": "^1.3.2",
     "babel-preset-react": "^6.22.0",
     "express": "^4.14.1",
     "react": "^15.4.2",


### PR DESCRIPTION
Seems babel-preset-latest is deprecated and npm install gives this warning.
```
npm WARN deprecated babel-preset-latest@6.24.0: 💥  preset-latest accomplishes the same task as babel-preset-env. 🙏  Please install it with 'npm install babel-preset-env --save-dev'. '{ "presets": ["latest"] }' to '{ "presets": ["env"] }'. For more info, please check the docs: http://babeljs.io/docs/plugins/preset-env 👌. And let us know how you're liking Babel at @babeljs on 🐦
```

According to https://babeljs.io/docs/plugins/preset-env/#how-it-works-support-all-plugins-in-babel-that-are-considered-latest, `babel-preset-env` should behave as babel-preset-latest, and can just be replaced.

Btw, loved your BYOS :+1: 

Cheers,
Marius :beer: 