### PR TITLE
Fix webpack error for new webpack release

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "compile": "webpack",
-    "build": "webpack -p",
+    "build": "webpack --mode production",
     "start": "node server.js"
   },
   "keywords": [


### PR DESCRIPTION
The command `npm run build` threw the error: `error: unknown option '-p'`. The argument changed to `--mode production` in a recent release (https://github.com/webpack/webpack-cli/issues/1934).